### PR TITLE
Display legion's main score

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -1230,6 +1230,7 @@ do
 
 		-- BFA
 		cache.legionScore = RoundNumber(cache.allScore, 10)
+		cache.legionMainScore = RoundNumber(cache.mainScore, 10)
 		cache.allScore = 0
 		cache.isPrevAllScore = false
 		cache.mainScore = 0
@@ -1398,6 +1399,7 @@ local GetFormattedRunCount
 local AppendGameTooltip
 local UpdateAppendedGameTooltip
 local AppendAveragePlayerScore
+local AddLegionScore
 do
 	local function sortRoleScores(a, b)
 		return a[2] > b[2]
@@ -1417,6 +1419,16 @@ do
 			return '250+'
 		else
 			return count
+		end
+	end
+
+	function AddLegionScore(tooltip, profile)
+		if profile.legionScore and profile.legionScore > 0 then
+			if profile.legionMainScore and profile.legionMainScore > profile.legionScore then
+				tooltip:AddDoubleLine(L.LEGION_MAIN_SCORE, GetFormattedScore(profile.legionMainScore), 1, 1, 1, 1, 1, 1)
+			else
+				tooltip:AddDoubleLine(L.LEGION_SCORE, GetFormattedScore(profile.legionScore), 1, 1, 1, 1, 1, 1)
+			end
 		end
 	end
 
@@ -1461,9 +1473,7 @@ do
 				tooltip:AddDoubleLine(L.RAIDERIO_MP_SCORE, L.UNKNOWN_SCORE, 1, 0.85, 0, 1, 1, 1)
 			end
 
-			if profile.legionScore > 0 then
-				tooltip:AddDoubleLine(L.LEGION_SCORE, GetFormattedScore(profile.legionScore), 1, 1, 1, 1, 1, 1)
-			end
+			AddLegionScore(tooltip, profile)
 
 			-- choose the best highlight to show:
 			-- if user has a recorded run at higher level than their highest
@@ -1742,9 +1752,7 @@ do
 
 		profileTooltip:AddDoubleLine(profile.name, GetFormattedScore(profile.allScore, profile.isPrevAllScore), 1, 1, 1, GetScoreColor(profile.allScore))
 
-		if profile.legionScore and profile.legionScore > 0 then
-			profileTooltip:AddDoubleLine(L.LEGION_SCORE, GetFormattedScore(profile.legionScore), 1, 1, 1, 1, 1, 1)
-		end
+		AddLegionScore(profileTooltip, profile)
 
 		if profile.mainScore > profile.allScore then
 			profileTooltip:AddDoubleLine(L.MAINS_SCORE, profile.mainScore, 1, 1, 1, GetScoreColor(profile.mainScore))

--- a/core.lua
+++ b/core.lua
@@ -1423,12 +1423,10 @@ do
 	end
 
 	function AddLegionScore(tooltip, profile)
-		if profile.legionScore and profile.legionScore > 0 then
-			if profile.legionMainScore and profile.legionMainScore > profile.legionScore then
-				tooltip:AddDoubleLine(L.LEGION_MAIN_SCORE, GetFormattedScore(profile.legionMainScore), 1, 1, 1, 1, 1, 1)
-			else
-				tooltip:AddDoubleLine(L.LEGION_SCORE, GetFormattedScore(profile.legionScore), 1, 1, 1, 1, 1, 1)
-			end
+		if profile.legionScore and profile.legionScore > 0 and (not profile.legionMainScore or profile.legionMainScore <= profile.legionScore) then
+			tooltip:AddDoubleLine(L.LEGION_SCORE, GetFormattedScore(profile.legionScore), 1, 1, 1, 1, 1, 1)
+		elseif profile.legionMainScore and (not profile.legionScore or profile.legionMainScore > profile.legionScore) then
+			tooltip:AddDoubleLine(L.LEGION_MAIN_SCORE, GetFormattedScore(profile.legionMainScore), 1, 1, 1, 1, 1, 1)
 		end
 	end
 

--- a/locale/enUS.lua
+++ b/locale/enUS.lua
@@ -110,5 +110,6 @@ L.SHOW_CLIENT_GUILD_BEST_DESC = "Enabling this will display your guild's Top 5 r
 L.CHECKBOX_DISPLAY_WEEKLY = "Display Weekly"
 L.NO_GUILD_RECORD = "No Guild Records"
 L.LEGION_SCORE = "Legion Score"
+L.LEGION_MAIN_SCORE = "Legion Main's Score"
 
 ns.L = L


### PR DESCRIPTION
As discussed, if the legion's main score is above the the legion score of the character, we display the legion's main score instead.

[Example](https://file.wisak.me/f/ewDKWUIdlJ.png)