### PR TITLE
Allow to search by slug

### DIFF
--- a/search.lua
+++ b/search.lua
@@ -66,8 +66,10 @@ local function GetRealms(text, maxResults, cursorPosition)
 					if count >= maxResults then
 						break
 					end
+
+					local realmSlug = ns.realmSlugs[k]
 					kl = k:lower()
-					if not unique[kl] and kl:find(text, nil, true) == 1 then
+					if not unique[kl] and (kl:find(text, nil, true) == 1 or (realmSlug and realmSlug:find(text, nil, true)))  then
 						unique[kl] = true
 						count = count + 1
 						temp[count] = {


### PR DESCRIPTION
On the search panel, allow to search by slug as well as the name (before it was only the name).

This allows to search for the latin name instead of the Korean or Taiwanese version.

![image](https://user-images.githubusercontent.com/5872952/74480653-a608e480-4eb1-11ea-95fe-4e59b409db45.png)
