### PR TITLE
Searching for player profile is now case insensitive to resolve an extremely rare issue

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -1978,16 +1978,17 @@ do
     end
 
     local function BinarySearchGetIndexFromName(data, name, startIndex, endIndex)
+        local lcname = name:lower()
         local minIndex = startIndex
         local maxIndex = endIndex
         local mid, current
 
         while minIndex <= maxIndex do
             mid = floor((maxIndex + minIndex) / 2)
-            current = data[mid]
-            if current == name then
+            current = data[mid]:lower()
+            if current == lcname then
                 return mid
-            elseif current < name then
+            elseif current < lcname then
                 minIndex = mid + 1
             else
                 maxIndex = mid - 1


### PR DESCRIPTION
Fixed an extremely rare issue where names changed by GM, but capitalized poorly, did not always find the players profile. Capitalization is now ignored when searching for the player profile to resolve this issue.