### PR TITLE
No need to check bronze limit, force 1 upgrade if timed

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -2934,12 +2934,11 @@ do
                     local runSeconds = run.bestRunDurationMS / 1000
                     local runNumUpgrades = 0
                     if run.finishedSuccess then
+						runNumUpgrades = 1 -- minimum 1 if timed
                         if runSeconds <= goldTimeLimit then
                             runNumUpgrades = 3
                         elseif runSeconds <= silverTimeLimit then
                             runNumUpgrades = 2
-                        elseif runSeconds <= bronzeTimeLimit then
-                            runNumUpgrades = 1
                         end
                     end
                     local runTimerAsFraction = runSeconds / (dungeonTimeLimit and dungeonTimeLimit > 0 and dungeonTimeLimit or 1) -- convert game timer to a fraction (1 or below is timed, above is depleted)


### PR DESCRIPTION
The "real" time is actually a bit more than what the dungeon limit truly is.

This force the upgrade to be 1 if it's marked as timed

cf:

![image](https://user-images.githubusercontent.com/5872952/124498137-2b997700-ddbc-11eb-8ca9-1ad496fd8bdb.png)

![image](https://user-images.githubusercontent.com/5872952/124498216-453abe80-ddbc-11eb-8d19-e3c9ebdd7095.png)
