### PR TITLE
Change to BigWigs Packager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
         with:
           fetch-depth: 50
       - name: Package and release
-        uses: BigWigsMods/packager@v2
+        uses: BigWigsMods/packager@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Package and release
+
+on:
+  push:
+    tags:
+      - '**'
+
+env:
+  CF_API_KEY: ${{ secrets.CF_API_KEY }}
+  WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
+  WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+  GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}  # "GITHUB_TOKEN" is a secret always provided to the workflow for your own token, the name cannot start with "GITHUB_"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 50
+      - name: Package and release
+        uses: BigWigsMods/packager@v2

--- a/RaiderIO.toc
+++ b/RaiderIO.toc
@@ -1,9 +1,10 @@
-## Interface: 90105
+## Interface: 90200
 ## Title: Raider.IO Mythic Plus and Raiding
 ## Notes: Shows Raider.IO Mythic+ Score and Raid Progress in-game. Make sure to load one or more region DB.
 ## Author: Vladinator (Vladinator-TarrenMill), Aspyr (Aspyrox-Skullcrusher) and Isak (Isak-Sargeras)
-## Version: 9.1.5 (@project-version@)
+## Version: 9.2.0 (@project-version@)
 ## SavedVariables: RaiderIO_Config, RaiderIO_LastCharacter, RaiderIO_MissingCharacters, RaiderIO_MissingServers, RaiderIO_CachedRuns, RaiderIO_RWF
 ## X-Website: https://raider.io
 ## X-AddonProvider: github
+## X-Curse-Project-ID: 279257
 core.xml


### PR DESCRIPTION
Due to complications caused by the CurseForge packager not always playing ball, changing over to the BigWigs Packager will allow us to become CurseForge independent and packaging will be more reliable.

Before changing, we would need to update the GitHub project settings and add the API key for CF.
Then disable the CF project automatic packaging option so we avoid running the old packaging process.

Once the pull request is merged into the main branch we can like before create releases by pushing a tag to the repo, then the new action will package the addon and publish it to CF directly from GitHub.

Future tagged releases will also be finalized on GitHub, meaning any tags for content substitution, localization, changelog, and so on, will be properly generated when publishing, so other addon clients can directly fetch the releases from GitHub as well as a positive side-effect of this change.