### PR TITLE
Unlocked profile anchor has a proper tooltip when hovering

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -5545,7 +5545,7 @@ do
     end
 
     local function CreateTooltipAnchor()
-        local frame = CreateFrame("Frame", nil, fallbackFrame)
+        local frame = CreateFrame("Frame", addonName .. "_ProfileTooltipAnchor", fallbackFrame)
         frame:SetFrameStrata(fallbackStrata)
         frame:SetFrameLevel(100)
         frame:SetClampedToScreen(true)
@@ -5559,6 +5559,14 @@ do
         frame.Icon = frame:CreateTexture(nil, "ARTWORK")
         frame.Icon:SetAllPoints()
         frame.Icon:SetTexture(386863)
+        frame:SetScript("OnEnter", function()
+            GameTooltip:SetOwner(frame, "ANCHOR_RIGHT")
+            GameTooltip:SetText(L.PROFILE_TOOLTIP_ANCHOR_TOOLTIP, 1, 1, 1)
+            GameTooltip:Show()
+        end)
+        frame:SetScript("OnLeave", function()
+            GameTooltip:Hide()
+        end)
         return frame
     end
 

--- a/core.lua
+++ b/core.lua
@@ -4390,6 +4390,10 @@ do
     ---@param onEnter function @Optional function, the OnEnter handler that we can also compare against for matches.
     local function IsSafeFrame(frame, onEnter)
         local parent = frame:GetParent()
+        -- the tooltip anchor frame doesn't have a OnEnter we can use to re-render the tooltip
+        if frame == _G.RaiderIO_ProfileTooltipAnchor then
+            return false
+        end
         -- LFGListSearchEntry_OnEnter > LFGListUtil_SetSearchEntryTooltip > C_LFGList.GetPlaystyleString
         if onEnter == _G.LFGListSearchEntry_OnEnter or (frame.resultID and parent == _G.LFGListSearchPanelScrollFrameScrollChild) then
             return false
@@ -5559,8 +5563,8 @@ do
         frame.Icon = frame:CreateTexture(nil, "ARTWORK")
         frame.Icon:SetAllPoints()
         frame.Icon:SetTexture(386863)
-        frame:SetScript("OnEnter", function()
-            GameTooltip:SetOwner(frame, "ANCHOR_RIGHT")
+        frame:SetScript("OnEnter", function(self)
+            GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
             GameTooltip:SetText(L.PROFILE_TOOLTIP_ANCHOR_TOOLTIP, 1, 1, 1)
             GameTooltip:Show()
         end)

--- a/locale/enUS.lua
+++ b/locale/enUS.lua
@@ -116,6 +116,7 @@ L.ENABLE_LOCK_PROFILE_FRAME_DESC = "Prevents the M+ Profile Frame from being dra
 L.WARNING_LOCK_POSITION_FRAME_AUTO = "Raider.IO: You must disable Automatic Positioning for Raider.IO Profile first."
 L.LOCKING_PROFILE_FRAME = "Raider.IO: Locking the M+ Profile Frame."
 L.UNLOCKING_PROFILE_FRAME = "Raider.IO: Unlocking the M+ Profile Frame."
+L.PROFILE_TOOLTIP_ANCHOR_TOOLTIP = "Lock Raider.IO Profile Frame or enable Automatic Positioning in order to hide this anchor."
 L.RAIDERIO_CLIENT_CUSTOMIZATION = "Raider.IO Client Customization"
 L.ENABLE_RAIDERIO_CLIENT_ENHANCEMENTS = "Allow Raider.IO Client Enhancements"
 L.ENABLE_RAIDERIO_CLIENT_ENHANCEMENTS_DESC = "Enabling this will allow you to view detailed Raider.IO Profile data downloaded from the Raider.IO Client for your claimed characters."


### PR DESCRIPTION
After we added the anchor, some players noticed the anchor frame, previously the tooltip itself was draggable, but now that we have an anchor, they didn't know the origin of this frame (it was also nameless) or how to remove it. The tooltip will help know it is RIO related and guide how to remove it, by either locking the frame or setting the profile to position automatically.