### PR TITLE
fixed death penalty map for replays to account for season 2

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -8641,8 +8641,8 @@ if IS_RETAIL then
 
     ---@type KeystoneDeathPenaltyInfo[]
     local DEATH_PENALTY_MAP = {
-        { level = 7, penalty = 15 },
-        { level = 0, penalty = 5 },
+        { level = 12, penalty = 15 },
+        { level = 4, penalty = 5 },
     }
 
     ---@class ReplayDataProvider
@@ -8717,8 +8717,7 @@ if IS_RETAIL then
                     return deathPenalty.penalty
                 end
             end
-            local deathPenalty = deathPenaltyMap[#deathPenaltyMap]
-            return deathPenalty.penalty
+            return 0 -- default to no death penalty
         end
 
         ---@return ReplaySummary replaySummary


### PR DESCRIPTION
This addresses issue with the death penalty for replays to account for season 2 affix changes:
- no penalty at 2/3
- +5 seconds per death at 4-11
- +15 seconds per death at 12+