### PR TITLE
The "Report Advertisement" fix is no longer needed.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,8 +82,6 @@
         "ItemRefTooltip",
         "LE_REALM_RELATION_SAME",
         "LE_WORLD_ELAPSED_TIMER_TYPE_CHALLENGE_MODE",
-        "LFGList_ReportAdvertisement",
-        "LFGList_ReportListing",
         "LFGListFrame",
         "LFGListFrameDropDown",
         "LinkUtil",

--- a/core.lua
+++ b/core.lua
@@ -7502,13 +7502,6 @@ if not IS_CLASSIC_ERA then
             frame:EnableMouseWheel(false)
             frame:SetToplevel(false)
         end
-        -- this issue has been lingering for a while, so it might be worth to add this workaround to avoid taint breaking issues
-        -- it only affects the dropdown option "Report Advertisement" that would without this fix block due to taint
-        -- we can't avoid this because it automatically happens when we modify the dropdown menu (even when using the intended method)
-        -- https://github.com/Stanzilla/WoWUIBugs/issues/237
-        if LFGList_ReportAdvertisement and LFGList_ReportListing then
-            LFGList_ReportAdvertisement = LFGList_ReportListing
-        end
     end
 
 end


### PR DESCRIPTION
Since 11.2.5 the taint issue is fixed so removing the old code that cause the report dialog to appear.