### PR TITLE
Additional Midnight error edge cases

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -6350,7 +6350,23 @@ do
             tooltip:SetOwner(o1, o2, o3, o4) ---@diagnostic disable-line: param-type-mismatch
         end
         if p1 then
-            tooltip:SetPoint(p1, p2, p3, p4, p5)
+            if p2 and p3 then
+                if p4 and p5 then
+                    tooltip:SetPoint(p1, p2, p3, p4, p5)
+                else
+                    tooltip:SetPoint(p1, p2, p3)
+                end
+            elseif p2 then
+                if p4 and p5 then
+                    tooltip:SetPoint(p1, p2, p4, p5)
+                else
+                    tooltip:SetPoint(p1, p2)
+                end
+            elseif p4 and p5 then
+                tooltip:SetPoint(p1, p4, p5)
+            else
+                tooltip:SetPoint(p1)
+            end
         end
         if not o1 and a1 then
             tooltip:SetAnchorType(a1, a2, a3)
@@ -7799,9 +7815,9 @@ do
         if not config:Get("enableGuildTooltips") then
             return
         end
-        local clubType
-        local nameAndRealm
-        local level
+        local clubType ---@type Enum.ClubType?
+        local nameAndRealm ---@type string?
+        local level ---@type number?
         local faction = ns.PLAYER_FACTION
         if type(self.GetMemberInfo) == "function" then
             local info = self:GetMemberInfo()
@@ -7828,6 +7844,9 @@ do
                     faction = util:GetFactionFromRace(race, faction)
                 end
             end
+        end
+        if issecretvalue(clubType) or issecretvalue(nameAndRealm) or issecretvalue(level) then
+            return
         end
         if (clubType and clubType ~= Enum.ClubType.Guild and clubType ~= Enum.ClubType.Character) or not nameAndRealm or not util:IsMaxLevel(level, true) then
             return

--- a/core.lua
+++ b/core.lua
@@ -6350,23 +6350,7 @@ do
             tooltip:SetOwner(o1, o2, o3, o4) ---@diagnostic disable-line: param-type-mismatch
         end
         if p1 then
-            if p2 and p3 then
-                if p4 and p5 then
-                    tooltip:SetPoint(p1, p2, p3, p4, p5)
-                else
-                    tooltip:SetPoint(p1, p2, p3)
-                end
-            elseif p2 then
-                if p4 and p5 then
-                    tooltip:SetPoint(p1, p2, p4, p5)
-                else
-                    tooltip:SetPoint(p1, p2)
-                end
-            elseif p4 and p5 then
-                tooltip:SetPoint(p1, p4, p5)
-            else
-                tooltip:SetPoint(p1)
-            end
+            tooltip:SetPoint(p1, p2, p3 or p1, p4 or 0, p5 or 0)
         end
         if not o1 and a1 then
             tooltip:SetAnchorType(a1, a2, a3)

--- a/core.lua
+++ b/core.lua
@@ -6262,7 +6262,7 @@ do
                         end
                     end
                     if easterEgg then
-                        tooltip:AddLine(easterEgg, 0.9, 0.8, 0.5)
+                        tooltip:AddLine(easterEgg, 0.9, 0.8, 0.5) ---@diagnostic disable-line: param-type-mismatch
                     end
                 end
                 -- profile added to tooltip successfully
@@ -7449,7 +7449,11 @@ do
     ---@param region? RegionString
     local function IsPlayer(unit, name, realm, region)
         if unit and UnitExists(unit) then
-            return UnitIsUnit(unit, "player")
+            local isPlayer = UnitIsUnit(unit, "player")
+            if issecretvalue(isPlayer) then
+                return false
+            end
+            return isPlayer
         end
         return name == ns.PLAYER_NAME and realm == ns.PLAYER_REALM and (not region or region == ns.PLAYER_REGION)
     end
@@ -15319,13 +15323,14 @@ do
             end
         else
             local unit = ...
-            if issecretvalue(unit) or not unit or not UnitIsPlayer(unit) or UnitIsUnit(unit, "player") then
+            if issecretvalue(unit) or not unit or not UnitIsPlayer(unit) then
                 return
             end
-            local guid = UnitGUID(unit)
-            if guid then
-                InspectPlayerGUID(guid)
+            local isPlayer = UnitIsUnit(unit, "player")
+            if issecretvalue(isPlayer) or isPlayer then
+                return
             end
+            InspectPlayerGUID(UnitGUID(unit))
         end
     end
 


### PR DESCRIPTION
Recent patch added additional changes that would sometimes error.

These are dependent on the environment, where the player is and what kind of lockdown is applied to the UI.

There was also a new odd error with how setting the tooltip position would start to error, so this PR will hopefully avoid these two error cases:

```lua
1x GameTooltip:SetPoint(): Usage: ("point" [, region or nil] [, "relativePoint"] [, offsetX, offsetY]
[RaiderIO/core.lua]:6353: in function <RaiderIO/core.lua:6302>
[RaiderIO/core.lua]:6376: in function 'callbackFunc'
[RaiderIO/core.lua]:1659: in function 'SendEvent'
[RaiderIO/core.lua]:1594: in function <RaiderIO/core.lua:1590>
```

```lua
1x RaiderIO/core.lua:7832: attempt to compare local 'clubType' (a secret number value tainted by 'RaiderIO')
[RaiderIO/core.lua]:7832: in function <RaiderIO/core.lua:7798>
[C]: ?
```

The first simply ensures that the anchor follows the same parameters in the call as in the documentation. It was apparently possible for a strange mix to lead into a state that errored. The downside of this is having to keep this up to date if the `SetPoint` changes, but this should rarely be the case, and this is better than just a `pcall` wrapper.

The second checks if any of the values are secrets and avoids performing logic on them. This will most likely occur during encounter combat of some kind, though I was unable to reproduce it myself, the issue, because `taint` is involved, could also be something else going wrong.

In any case, this PR would need a bit of testing before being merged. Simply to ensure that no new errors appear when:
- Hovering over things and players in both world but especially in instance and instance combat.
- Hovering over people in the community list frame, guild community list frame, and ensuring no errors occur when in an instance and in instance combat.
