### PR TITLE
Added secret value check when trying to get a unit name and realm

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -2511,6 +2511,9 @@ do
             unit = arg1
             if unitIsPlayer then
                 name, realm = UnitNameUnmodified(arg1)
+                if issecretvalue(name) or issecretvalue(realm) then
+                    return
+                end
                 realm = realm and realm ~= "" and realm or GetNormalizedRealmName()
             end
             return name, realm, unit


### PR DESCRIPTION
This was missed in the earlier hotfix PR that added a significant amount of secret value checks.

This PR should fix:
- #369
