### PR TITLE
MOP bugfix

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -548,6 +548,9 @@ end
 ---@param tooltip GameTooltip
 ---@return nil nil, UnitToken? unit, string? guid
 local function GetTooltipUnit(tooltip)
+    if not tooltip.IsTooltipType then
+        return tooltip:GetUnit()
+    end
     if not tooltip:IsTooltipType(Enum.TooltipDataType.Unit) then
         return
     end


### PR DESCRIPTION
The recent change to how a tooltip unit is retrieved, wouldn't work on the other flavors of the game.

This adjustment should suffice, but would be good to test it and make sure.