### PR TITLE
Add support to close dialogs when Escape is pressed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -132,6 +132,7 @@
         "UIDROPDOWNMENU_MAXBUTTONS",
         "UIDropDownMenuButton_OpenColorPicker",
         "UIParentRightManagedFrameContainer",
+        "UISpecialFrames",
         "UnitPopupSharedUtil",
         "WHISPER",
         "WHISPER_LEADER",

--- a/core.lua
+++ b/core.lua
@@ -12681,6 +12681,7 @@ do
             Frame:EnableMouse(true)
             Frame:SetFrameStrata("DIALOG")
             Frame:SetToplevel(true)
+            table.insert(UISpecialFrames, Frame:GetName())
             Frame:SetSize(310, config:Get("debugMode") and 115 or 100)
             Frame:SetPoint("CENTER")
             if Frame.SetBackdrop then
@@ -15585,6 +15586,7 @@ if IS_RETAIL then
         self:SetToplevel(true)
         self:SetMovable(true)
         self:SetClampedToScreen(true)
+        table.insert(UISpecialFrames, self:GetName())
 
         local frameWidth, frameHeight = 640, 20 + 43 + (buildsButtonHeight * 8) + 22
         self:SetSize(frameWidth, frameHeight)
@@ -16699,6 +16701,8 @@ do
         local configParentFrame = CreateFrame("Frame", format("%s_SettingsFrame", addonName), UIParent, BackdropTemplateMixin and "BackdropTemplate")
         configParentFrame:SetSize(400, 600)
         configParentFrame:SetPoint("CENTER")
+        configParentFrame:SetToplevel(true)
+        table.insert(UISpecialFrames, configParentFrame:GetName())
 
         ---@class RaiderIOSettingsFrameHeaderFrame : Frame
         local configHeaderFrame = CreateFrame("Frame", nil, configParentFrame)


### PR DESCRIPTION
Added the following frames to the `UISpecialFrames` table (which in turn makes the default UI handle closing behavior the same way as with other frames):
- Settings frame (`/rio`)
- Search dialog (`/rio search`)
- Talent Builds frame (`/rio talents`)

Relevant issue:
- #381 
