### PR TITLE
Match the tooltip guid to a group unit token when UnitTokenFromGUID returns nil

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -874,6 +874,26 @@ local function issecretvaluekey(tbl, ...)
     return false
 end
 
+-- `UnitTokenFromGUID` resolves interaction tokens such as `target` and `mouseover`, but returns nil for a party or raid member's guid while a unit tooltip is being built, so unit frames showing group members supply no token there.
+---@param guid string
+---@return UnitToken? unit
+local function GetGroupUnitTokenFromGUID(guid)
+    if UnitGUID("player") == guid then
+        return "player"
+    end
+    local prefix, count = "party", GetNumSubgroupMembers()
+    if IsInRaid() then
+        prefix, count = "raid", GetNumGroupMembers()
+    end
+    for i = 1, count do
+        local unit = prefix .. i
+        local unitGuid = UnitGUID(unit)
+        if not issecretvalue(unitGuid) and unitGuid == guid then
+            return unit
+        end
+    end
+end
+
 -- The `GameTooltip.IsTooltipType` doesn't exist in older flavors. In which case we will call the legacy `GetUnit` as those flavors don't have the secret value system.
 ---@param tooltip GameTooltip | { IsTooltipType: (fun(self: GameTooltip, type: Enum.TooltipDataType): boolean)?, GetPrimaryTooltipData: fun(self: GameTooltip): { guid: string? } }
 ---@return nil nil, UnitToken? unit, string? guid
@@ -890,6 +910,9 @@ local function GetTooltipUnit(tooltip)
         return
     end
     local unit = UnitTokenFromGUID(guid)
+    if issecretvalue(unit) or not unit then
+        unit = GetGroupUnitTokenFromGUID(guid)
+    end
     return nil, unit, guid
 end
 


### PR DESCRIPTION
Unit tooltips for a party or raid member resolve to no unit: the guid is readable, but `UnitTokenFromGUID` on it returns nil while the tooltip is being built, so `OnTooltipSetUnit` bails and no score is drawn. Tooltips anchored to `target` or `focus` are unaffected, since those tokens persist and resolve. This reaches any unit frame that shows group members, Blizzard's included. EllesmereUI already carries a Raider.IO-specific workaround in its raid frames that calls `ShowProfile` with a guid-matched token, but the fix belongs here so every frame gets it.

Use the guid directly when the unit token is secret or missing by comparing it to `player`, `partyN`, and `raidN`.

Tested with Grid2 raid frames on a 12.1.0 client: the score draws where it did not before. The nil token and readable `UnitGUID` results behind it were measured both in and out of instance combat.
